### PR TITLE
Fix issue with speed cost being incorrectly calculated

### DIFF
--- a/hft/market_elements/subscription.py
+++ b/hft/market_elements/subscription.py
@@ -37,6 +37,8 @@ class Subscription:
             log.warning('already active %s' % self)
 
     def deactivate(self):
+        if not self.is_active:
+            return
         self.timer.step()
         self.__active = False
         self.__uninvoiced_time += round(self.timer.time_since_previous_step, 3)


### PR DESCRIPTION
The problem was that the speed tracking service was not properly handling the case where it was deactivated twice in a row. This was causing it to erroneously consider extra time as having speed on. This fix adds proper handling for this case which seems to have fixed the overall issue with speed cost.